### PR TITLE
Added SPI Transaction Support

### DIFF
--- a/SPIFlash.cpp
+++ b/SPIFlash.cpp
@@ -7,6 +7,7 @@
  * DEPENDS ON: Arduino SPI library
  *
  * Updated Jan. 5, 2015, TomWS1, modified writeBytes to allow blocks > 256 bytes and handle page misalignment.
+ * Updated Feb. 26, 2015 TomWS1, added support for SPI Transactions (Arduino 1.5.8 and above)
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2
@@ -34,15 +35,22 @@ SPIFlash::SPIFlash(uint8_t slaveSelectPin, uint16_t jedecID) {
 
 /// Select the flash chip
 void SPIFlash::select() {
-  noInterrupts();
   //save current SPI settings
+#ifndef SPI_HAS_TRANSACTION
+  _SREG = SREG;
+  noInterrupts();
+#endif
   _SPCR = SPCR;
   _SPSR = SPSR;
-  //set FLASH chip SPI settings
+
+#ifdef SPI_HAS_TRANSACTION
+  SPI.beginTransaction(_settings);
+#else
+  // set FLASH SPI settings
   SPI.setDataMode(SPI_MODE0);
   SPI.setBitOrder(MSBFIRST);
-  SPI.setClockDivider(SPI_CLOCK_DIV4); //decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
-  SPI.begin();
+  SPI.setClockDivider(SPI_CLOCK_DIV4); // decided to slow down from DIV2 after SPI stalling in some instances, especially visible on mega1284p when RFM69 and FLASH chip both present
+#endif
   digitalWrite(_slaveSelectPin, LOW);
 }
 
@@ -50,9 +58,13 @@ void SPIFlash::select() {
 void SPIFlash::unselect() {
   digitalWrite(_slaveSelectPin, HIGH);
   //restore SPI settings to what they were before talking to the FLASH chip
+#ifdef SPI_HAS_TRANSACTION
+  SPI.endTransaction();
+#else  
+  SREG = _SREG;  // restore interrupts IFF they were enabled
+#endif
   SPCR = _SPCR;
   SPSR = _SPSR;
-  interrupts();
 }
 
 /// setup SPI, read device ID etc...
@@ -60,7 +72,10 @@ boolean SPIFlash::initialize()
 {
   _SPCR = SPCR;
   _SPSR = SPSR;
+  digitalWrite(_slaveSelectPin, HIGH);
   pinMode(_slaveSelectPin, OUTPUT);
+  SPI.begin();
+  _settings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
   unselect();
   wakeup();
   
@@ -194,26 +209,25 @@ void SPIFlash::writeByte(long addr, uint8_t byt) {
 ///
 void SPIFlash::writeBytes(long addr, const void* buf, uint16_t len) {
   uint16_t n;
-  uint16_t maxBytes = 256-(addr%256);  // force the first set of bytes to stay within the first page
+  uint16_t maxBytes = 256-(addr%256); // force the first set of bytes to stay within the first page
   uint16_t offset = 0;
   while (len>0)
   {
     n = (len<=maxBytes) ? len : maxBytes;
-    command(SPIFLASH_BYTEPAGEPROGRAM, true);  // Byte/Page Program
+    command(SPIFLASH_BYTEPAGEPROGRAM, true); // Byte/Page Program
     SPI.transfer(addr >> 16);
     SPI.transfer(addr >> 8);
     SPI.transfer(addr);
-    
     for (uint16_t i = 0; i < n; i++)
       SPI.transfer(((byte*) buf)[offset + i]);
     unselect();
-    
-    addr+=n;  // adjust the addresses and remaining bytes by what we've just transferred.
+    addr+=n; // adjust the addresses and remaining bytes by what we've just transferred.
     offset +=n;
     len -= n;
-    maxBytes = 256;   // now we can do up to 256 bytes per loop
+    maxBytes = 256; // now we can do up to 256 bytes per loop
   }
 }
+
 
 /// erase entire flash memory array
 /// may take several seconds depending on size, but is non blocking

--- a/SPIFlash.h
+++ b/SPIFlash.h
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2013 by Felix Rusu <felix@lowpowerlab.com>
  * SPI Flash memory library for arduino/moteino.
- * This works with 256byte/page SPI flash memory
- * For instance a 4MBit (512Kbyte) flash chip will have 2048 pages: 256*2048 = 524288 bytes (512Kbytes)
+ * This works with 256uint8_t/page SPI flash memory
+ * For instance a 4MBit (512Kuint8_t) flash chip will have 2048 pages: 256*2048 = 524288 uint8_ts (512Kuint8_ts)
  * Minimal modifications should allow chips that have different page size but modifications
  * DEPENDS ON: Arduino SPI library
+ *
+ * Updated Feb. 26, 2015 TomWS1, added support for SPI Transactions (Arduino 1.5.8 and above)
  *
  * This file is free software; you can redistribute it and/or modify
  * it under the terms of either the GNU General Public License version 2
@@ -56,34 +58,34 @@
                                               // but no actual need to wait for completion (instead need to check the status register BUSY bit)
 #define SPIFLASH_STATUSREAD       0x05        // read status register
 #define SPIFLASH_STATUSWRITE      0x01        // write status register
-#define SPIFLASH_ARRAYREAD        0x0B        // read array (fast, need to add 1 dummy byte after 3 address bytes)
+#define SPIFLASH_ARRAYREAD        0x0B        // read array (fast, need to add 1 dummy uint8_t after 3 address uint8_ts)
 #define SPIFLASH_ARRAYREADLOWFREQ 0x03        // read array (low frequency)
 
 #define SPIFLASH_SLEEP            0xB9        // deep power down
 #define SPIFLASH_WAKE             0xAB        // deep power wake up
-#define SPIFLASH_BYTEPAGEPROGRAM  0x02        // write (1 to 256bytes)
-#define SPIFLASH_IDREAD           0x9F        // read JEDEC manufacturer and device ID (2 bytes, specific bytes for each manufacturer and device)
+#define SPIFLASH_BYTEPAGEPROGRAM  0x02        // write (1 to 256uint8_ts)
+#define SPIFLASH_IDREAD           0x9F        // read JEDEC manufacturer and device ID (2 uint8_ts, specific uint8_ts for each manufacturer and device)
                                               // Example for Atmel-Adesto 4Mbit AT25DF041A: 0x1F44 (page 27: http://www.adestotech.com/sites/default/files/datasheets/doc3668.pdf)
                                               // Example for Winbond 4Mbit W25X40CL: 0xEF30 (page 14: http://www.winbond.com/NR/rdonlyres/6E25084C-0BFE-4B25-903D-AE10221A0929/0/W25X40CL.pdf)
 #define SPIFLASH_MACREAD          0x4B        // read unique ID number (MAC)
                                               
 class SPIFlash {
 public:
-  static byte UNIQUEID[8];
-  SPIFlash(byte slaveSelectPin, uint16_t jedecID=0);
+  static uint8_t UNIQUEID[8];
+  SPIFlash(uint8_t slaveSelectPin, uint16_t jedecID=0);
   boolean initialize();
-  void command(byte cmd, boolean isWrite=false);
-  byte readStatus();
-  byte readByte(long addr);
+  void command(uint8_t cmd, boolean isWrite=false);
+  uint8_t readStatus();
+  uint8_t readByte(long addr);
   void readBytes(long addr, void* buf, word len);
-  void writeByte(long addr, byte byt);
+  void writeByte(long addr, uint8_t byt);
   void writeBytes(long addr, const void* buf, uint16_t len);
   boolean busy();
   void chipErase();
   void blockErase4K(long address);
   void blockErase32K(long address);
   word readDeviceId();
-  byte* readUniqueId();
+  uint8_t* readUniqueId();
   
   void sleep();
   void wakeup();
@@ -91,10 +93,16 @@ public:
 protected:
   void select();
   void unselect();
-  byte _slaveSelectPin;
+  uint8_t _slaveSelectPin;
   uint16_t _jedecID;
-  byte _SPCR;
-  byte _SPSR;
+  uint8_t _SPCR;
+  uint8_t _SPSR;
+  uint8_t _SREG;
+  
+#ifdef SPI_HAS_TRANSACTION
+  SPISettings _settings;
+#endif
+
 };
 
 #endif


### PR DESCRIPTION
Updated to use SPI Transaction support on Arduino V1.5.8 and above.
Tested on V1.5.8 and V1.6.0.

Note that in include file I changed 'byte' type updated to 'unint8_t' to match changes already made to .cpp file.