### PR TITLE
First attempt at correcting issue #26.

### DIFF
--- a/SPIFlash.cpp
+++ b/SPIFlash.cpp
@@ -200,7 +200,11 @@ boolean SPIFlash::busy()
   unselect();
   return status & 1;
   */
-  return readStatus() & 1;
+  if (chipPoweredDown){
+	return 0;
+  } else {
+	return readStatus() & 1;
+  } 
 }
 
 /// return the STATUS register
@@ -294,11 +298,13 @@ void SPIFlash::blockErase64K(uint32_t addr) {
 
 void SPIFlash::sleep() {
   command(SPIFLASH_SLEEP);
+  chipPoweredDown = true;
   unselect();
 }
 
 void SPIFlash::wakeup() {
   command(SPIFLASH_WAKE);
+  chipPoweredDown = false;
   unselect();
 }
 

--- a/SPIFlash.h
+++ b/SPIFlash.h
@@ -116,6 +116,7 @@ protected:
   uint16_t _jedecID;
   uint8_t _SPCR;
   uint8_t _SPSR;
+  bool chipPoweredDown = true;
 #ifdef SPI_HAS_TRANSACTION
   SPISettings _settings;
 #endif


### PR DESCRIPTION
busy() now returns if chip is **powered down** or **not busy**

previously noisy MISO line could cause uC to get stuck in busy()
if chip was powered down

Tested successfully with Moteino weather mote example.

Signed-off-by: JasonC0x0D <jasonc0x0d@gmail.com>
